### PR TITLE
Prevent default events when opening showrooms.

### DIFF
--- a/ftw/showroom/browser/client/dist/showroom.js
+++ b/ftw/showroom/browser/client/dist/showroom.js
@@ -199,6 +199,7 @@ module.exports = function Showroom() {
   };
 
   function select(event) {
+    event.preventDefault();
     var item = register.items.filter(function (item) {
       return item.id === event.currentTarget.getAttribute("data-showroom-id");
     })[0];

--- a/ftw/showroom/browser/client/src/showroom.js
+++ b/ftw/showroom/browser/client/src/showroom.js
@@ -73,6 +73,7 @@ module.exports = function Showroom(items = [], options) {
   };
 
   function select(event) {
+    event.preventDefault();
     let item = register.items.filter((item) => {
       return item.id === event.currentTarget.getAttribute("data-showroom-id");
     })[0];


### PR DESCRIPTION
This allows to create a Showroom for links.

```
npm test

> showroom@1.0.0 test /Users/deif/Files/workspaces/opengever.core/src/ftw.showroom/ftw/showroom/browser/client
> karma start

10 05 2016 11:23:38.326:INFO [framework.browserify]: registering rebuild (autoWatch=true)
10 05 2016 11:23:41.929:INFO [framework.browserify]: 2023769 bytes written (2.86 seconds)
10 05 2016 11:23:41.950:INFO [framework.browserify]: bundle built
10 05 2016 11:23:41.956:WARN [karma]: No captured browser, open http://localhost:9876/
10 05 2016 11:23:41.961:WARN [karma]: Port 9876 in use
10 05 2016 11:23:41.962:INFO [karma]: Karma v0.13.22 server started at http://localhost:9877/
10 05 2016 11:23:41.967:INFO [launcher]: Starting browser PhantomJS
10 05 2016 11:23:43.214:INFO [PhantomJS 1.9.8 (Mac OS X 0.0.0)]: Connected on socket /#gL-SlN3EuHDJAQiBAAAA with id 81579208
....................................
PhantomJS 1.9.8 (Mac OS X 0.0.0): Executed 36 of 36 SUCCESS (0.017 secs / 0.041 secs)
```