### PR TITLE
Use the manually set total of element instead of the size of the current batch.

### DIFF
--- a/ftw/showroom/js/src/showroom.js
+++ b/ftw/showroom/js/src/showroom.js
@@ -18,7 +18,8 @@ module.exports = function Showroom(items = [], options) {
     template,
     target: "body",
     displayCurrent: true,
-    displayTotal: true
+    displayTotal: true,
+    total: 0
   }, options);
 
   var reveal = {};
@@ -31,8 +32,9 @@ module.exports = function Showroom(items = [], options) {
             <span class="ftw-showroom-current">{{showroom.current}}</span>
           {{/if}}
           {{#if showroom.options.displayTotal}}
-            {{#if showroom.options.total}}<span>/</span>{{/if}}
-            <span class="ftw-showroom-total">{{showroom.options.total}}</span>
+            {{#if showroom.options.total}}<span>/</span>
+              <span class="ftw-showroom-total">{{showroom.options.total}}</span>
+            {{/if}}
           {{/if}}
         </div>
         <span class="ftw-showroom-title">{{item.title}}</span>
@@ -69,7 +71,7 @@ module.exports = function Showroom(items = [], options) {
   let isOpen = false;
 
   function checkArrows() {
-    if(!register.hasNext()) {
+    if(register.pointer >= options.total - 1) {
       $("#ftw-showroom-next", element).hide();
     }
     if(!register.hasPrev()) {

--- a/ftw/showroom/js/test/helpers/builder.js
+++ b/ftw/showroom/js/test/helpers/builder.js
@@ -29,7 +29,6 @@ export function singleShowroom() {
         <button id='ftw-showroom-prev'></button>
       `;
     },
-    target: "#outlet",
-    total: 10
+    target: "#outlet"
   });
 }

--- a/ftw/showroom/js/test/spec/showroom.js
+++ b/ftw/showroom/js/test/spec/showroom.js
@@ -75,7 +75,7 @@ describe("Showroom", () => {
       let showroom = Showroom(defaultItems);
 
       assert.equal(showroom.options.cssClass, "ftw-showroom");
-      assert.isUndefined(showroom.options.total);
+      assert.equal(showroom.options.total, 0);
     });
 
     it("displayOptions", () => {
@@ -115,8 +115,8 @@ describe("Showroom", () => {
       });
       showroom.open();
 
-      assert.isUndefined(showroom.total);
-      assert.equal(fixture.el.querySelector("#outlet .ftw-showroom-total").innerHTML, "");
+      assert.equal(showroom.options.total, 0);
+      assert.isNull(fixture.el.querySelector("#outlet .ftw-showroom-total"));
     });
 
   });
@@ -642,6 +642,7 @@ describe("Showroom", () => {
     it("should not show next arrows at the end the stream", () => {
 
       let showroom = Builder.defaultShowroom();
+      showroom.setTotal(5);
       showroom.open(showroom.items[4]);
 
       assert.equal(fixture.el.querySelector("#ftw-showroom-next").style.display, "none");
@@ -663,6 +664,15 @@ describe("Showroom", () => {
       let showroom = Builder.defaultShowroom();
       showroom.open();
       showroom.next();
+
+      assert.equal(fixture.el.querySelector("#ftw-showroom-next").style.display, "");
+      assert.equal(fixture.el.querySelector("#ftw-showroom-prev").style.display, "");
+    });
+
+    it("should show next arrow even when the manually set total is greather than the actual batch", () => {
+      let showroom = Builder.defaultShowroom();
+      showroom.setTotal(10);
+      showroom.open(showroom.items[4]);
 
       assert.equal(fixture.el.querySelector("#ftw-showroom-next").style.display, "");
       assert.equal(fixture.el.querySelector("#ftw-showroom-prev").style.display, "");

--- a/ftw/showroom/resources/showroom.js
+++ b/ftw/showroom/resources/showroom.js
@@ -352,12 +352,13 @@ module.exports = function Showroom() {
     template: template,
     target: "body",
     displayCurrent: true,
-    displayTotal: true
+    displayTotal: true,
+    total: 0
   }, options);
 
   var reveal = {};
 
-  var template = Handlebars.compile("\n    <div class=\"{{showroom.options.cssClass}}\">\n      <header class=\"ftw-showroom-header\">\n        <div class=\"ftw-showroom-left\">\n          {{#if showroom.options.displayCurrent}}\n            <span class=\"ftw-showroom-current\">{{showroom.current}}</span>\n          {{/if}}\n          {{#if showroom.options.displayTotal}}\n            {{#if showroom.options.total}}<span>/</span>{{/if}}\n            <span class=\"ftw-showroom-total\">{{showroom.options.total}}</span>\n          {{/if}}\n        </div>\n        <span class=\"ftw-showroom-title\">{{item.title}}</span>\n        <div class=\"ftw-showroom-right\">\n          <a id=\"ftw-showroom-close\" class=\"ftw-showroom-button\"></a>\n        </div>\n      </header>\n      <div class=\"ftw-showroom-content\">\n        {{{content}}}\n      </div>\n    </div>\n  ");
+  var template = Handlebars.compile("\n    <div class=\"{{showroom.options.cssClass}}\">\n      <header class=\"ftw-showroom-header\">\n        <div class=\"ftw-showroom-left\">\n          {{#if showroom.options.displayCurrent}}\n            <span class=\"ftw-showroom-current\">{{showroom.current}}</span>\n          {{/if}}\n          {{#if showroom.options.displayTotal}}\n            {{#if showroom.options.total}}<span>/</span>\n              <span class=\"ftw-showroom-total\">{{showroom.options.total}}</span>\n            {{/if}}\n          {{/if}}\n        </div>\n        <span class=\"ftw-showroom-title\">{{item.title}}</span>\n        <div class=\"ftw-showroom-right\">\n          <a id=\"ftw-showroom-close\" class=\"ftw-showroom-button\"></a>\n        </div>\n      </header>\n      <div class=\"ftw-showroom-content\">\n        {{{content}}}\n      </div>\n    </div>\n  ");
 
   var element = $();
 
@@ -386,7 +387,7 @@ module.exports = function Showroom() {
   var isOpen = false;
 
   function checkArrows() {
-    if (!register.hasNext()) {
+    if (register.pointer >= options.total - 1) {
       $("#ftw-showroom-next", element).hide();
     }
     if (!register.hasPrev()) {


### PR DESCRIPTION
When extending the current batch with items the next buttons is hidden because
the showroom does not use the manually total of elements to determine the last element.