### PR TITLE
Fix list unordered list styles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix unordered list styles.
+  [Kevin Bieri]
 
 
 1.1.0 (2016-06-27)

--- a/ftw/showroom/resources/style.css
+++ b/ftw/showroom/resources/style.css
@@ -1,14 +1,3 @@
-#content ul {
-  list-style-type: none;
-}
-
-#content ul li a.item {
-  display: block;
-  width: 100px;
-  height: 100px;
-  background-color: rgba(0, 0, 0, .2);
-}
-
 .ftw-showroom {
   z-index: 9999;
   position: fixed;


### PR DESCRIPTION
The selector `#content ul` is too specific. This may affect
projects where showroom gets integrated in.
See https://extranet.4teamwork.ch/support/gemeinde-duerrenaesch/tracker-support-gever-gemeinde-duerrenaesch/14

Elements with class `item` are not present in the showroom anyway.
So get rid of these obsolete stylings.