### PR TITLE
[refactor] Refactor event binding using event delegation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Refactor event binding using event delegation.
+  Since these changes all the showroom items must have `showroom-item` class
+  Therefore manually refreshing events is no longer necessary
 
 
 1.2.0 (2016-08-23)

--- a/ftw/showroom/js/src/showroom.js
+++ b/ftw/showroom/js/src/showroom.js
@@ -20,8 +20,7 @@ module.exports = function Showroom(items = [], options) {
     displayCurrent: true,
     displayTotal: true,
     total: 0,
-    offset: 0,
-    references: Array.prototype.slice.call(document.querySelectorAll(".showroom-reference"))
+    offset: 0
   }, options);
 
   setOffset(options.offset);
@@ -66,9 +65,6 @@ module.exports = function Showroom(items = [], options) {
   }
 
   items = items.map(item => Item(item));
-  items.map(item => $(item.element).on("click", select));
-
-  options.references.map(reference => $(reference).on("click", select));
 
   let register = Register(items, { tail: options.tail, head: options.head });
   let target = $(options.target);
@@ -90,11 +86,6 @@ module.exports = function Showroom(items = [], options) {
 
   function fetch(item) { return $.get(item.target); };
 
-  function bindEvents() {
-    element.on("click", "#ftw-showroom-next", throttledNext);
-    element.on("click", "#ftw-showroom-prev", throttledPrev);
-  };
-
   function render(content) {
     return $.when(content).pipe((content) => {
       return $(template({ showroom: reveal, content: content, item: register.current }));
@@ -108,7 +99,6 @@ module.exports = function Showroom(items = [], options) {
       element.show();
       isOpen = true;
       target.append(element).addClass("ftw-showroom-open");
-      bindEvents();
       checkArrows();
     });
   };
@@ -160,7 +150,6 @@ module.exports = function Showroom(items = [], options) {
   function append(nodes) {
     items = Array.prototype.slice.call(nodes);
     items = items.map(item => Item(item));
-    items.map(item => $(item.element).on("click", select));
     register.append(items);
     checkArrows();
   }
@@ -168,7 +157,6 @@ module.exports = function Showroom(items = [], options) {
   function prepend(nodes) {
     items = Array.prototype.slice.call(nodes);
     items = items.map(item => Item(item));
-    items.map(item => $(item.element).on("click", select));
     if (options.offset > 0) {
       options.offset -= items.length;
     }
@@ -180,15 +168,9 @@ module.exports = function Showroom(items = [], options) {
     close();
     items = Array.prototype.slice.call(items);
     items = items.map(item => Item(item));
-    items.map(item => $(item.element).on("click", select));
     setOffset(offset);
     register.reset(items);
     checkArrows();
-  }
-
-  function refresh() {
-    options.references = Array.prototype.slice.call(document.querySelectorAll(".showroom-reference"));
-    options.references.map(reference => $(reference).on("click", select));
   }
 
   function destroy() {
@@ -218,13 +200,17 @@ module.exports = function Showroom(items = [], options) {
     return register.pointer + 1 + options.offset;
   }
 
-  target.on("click", "#ftw-showroom-close", close);
-
-  target.on("keydown", (e) => {
-    event.isEscape(e, close);
-    event.isArrowRight(e, throttledNext);
-    event.isArrowLeft(e, throttledPrev);
-  });
+  $(document)
+    .on("click", "#ftw-showroom-close", close)
+    .on("keydown", (e) => {
+      event.isEscape(e, close);
+      event.isArrowRight(e, throttledNext);
+      event.isArrowLeft(e, throttledPrev);
+    })
+    .on("click", ".showroom-item", select)
+    .on("click", ".showroom-reference", select)
+    .on("click", "#ftw-showroom-prev", throttledPrev)
+    .on("click", "#ftw-showroom-next", throttledNext);
 
   reveal.open = open;
   reveal.close = close;
@@ -236,7 +222,6 @@ module.exports = function Showroom(items = [], options) {
   reveal.destroy = destroy;
   reveal.setTotal = setTotal;
   reveal.setOffset = setOffset;
-  reveal.refresh = refresh;
 
   Object.defineProperty(reveal, "options", { get: () => { return options; }});
   Object.defineProperty(reveal, "current", { get: () => { return current(); }});

--- a/ftw/showroom/js/test/fixtures/append_list.html
+++ b/ftw/showroom/js/test/fixtures/append_list.html
@@ -1,15 +1,15 @@
-<div class="item append" data-showroom-target="http://www.google.com">
+<div class="showroom-item append" data-showroom-target="http://www.google.com">
   <h1 class="title">6</h1>
 </div>
-<div class="item append" data-showroom-target="http://www.google.com">
+<div class="showroom-item append" data-showroom-target="http://www.google.com">
   <h1 class="title">7</h1>
 </div>
-<div class="item append" data-showroom-target="http://www.google.com">
+<div class="showroom-item append" data-showroom-target="http://www.google.com">
   <h1 class="title">8</h1>
 </div>
-<div class="item append" data-showroom-target="http://www.google.com">
+<div class="showroom-item append" data-showroom-target="http://www.google.com">
   <h1 class="title">9</h1>
 </div>
-<div class="item append" data-showroom-target="http://www.google.com">
+<div class="showroom-item append" data-showroom-target="http://www.google.com">
   <h1 class="title">10</h1>
 </div>

--- a/ftw/showroom/js/test/fixtures/default_item.html
+++ b/ftw/showroom/js/test/fixtures/default_item.html
@@ -1,1 +1,1 @@
-<div class="item" data-showroom-target="http://www.google.com" data-showroom-title="Google"></div>
+<div class="showroom-item" data-showroom-target="http://www.google.com" data-showroom-title="Google"></div>

--- a/ftw/showroom/js/test/fixtures/default_list.html
+++ b/ftw/showroom/js/test/fixtures/default_list.html
@@ -1,15 +1,15 @@
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">1</h1>
 </div>
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">2</h1>
 </div>
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">3</h1>
 </div>
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">4</h1>
 </div>
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">5</h1>
 </div>

--- a/ftw/showroom/js/test/fixtures/dirty_item_list.html
+++ b/ftw/showroom/js/test/fixtures/dirty_item_list.html
@@ -1,15 +1,15 @@
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">1</h1>
 </div>
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">2</h1>
 </div>
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">3</h1>
 </div>
-<div class="item" data-showroom-target-item="reference" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target-item="reference" data-showroom-target="http://www.google.com">
   <h1 class="title">4</h1>
 </div>
-<div class="item" data-showroom-target="http://www.google.com">
+<div class="showroom-item" data-showroom-target="http://www.google.com">
   <h1 class="title">5</h1>
 </div>

--- a/ftw/showroom/js/test/fixtures/prepend_list.html
+++ b/ftw/showroom/js/test/fixtures/prepend_list.html
@@ -1,15 +1,15 @@
-<div class="item prepend" data-showroom-target="http://www.google.com">
+<div class="showroom-item prepend" data-showroom-target="http://www.google.com">
   <h1 class="title">1</h1>
 </div>
-<div class="item prepend" data-showroom-target="http://www.google.com">
+<div class="showroom-item prepend" data-showroom-target="http://www.google.com">
   <h1 class="title">2</h1>
 </div>
-<div class="item prepend" data-showroom-target="http://www.google.com">
+<div class="showroom-item prepend" data-showroom-target="http://www.google.com">
   <h1 class="title">3</h1>
 </div>
-<div class="item prepend" data-showroom-target="http://www.google.com">
+<div class="showroom-item prepend" data-showroom-target="http://www.google.com">
   <h1 class="title">4</h1>
 </div>
-<div class="item prepend" data-showroom-target="http://www.google.com">
+<div class="showroom-item prepend" data-showroom-target="http://www.google.com">
   <h1 class="title">5</h1>
 </div>

--- a/ftw/showroom/js/test/helpers/builder.js
+++ b/ftw/showroom/js/test/helpers/builder.js
@@ -2,7 +2,7 @@ import Showroom from "showroom";
 
 export function defaultShowroom() {
   fixture.load("default_outlet.html", "default_list.html");
-  let defaultItems = fixture.el.querySelectorAll(".item");
+  let defaultItems = fixture.el.querySelectorAll(".showroom-item");
 
   return Showroom(defaultItems, {
     fetch: () => {
@@ -19,7 +19,7 @@ export function defaultShowroom() {
 
 export function singleShowroom() {
   fixture.load("default_outlet.html", "default_item.html");
-  let singleItem = fixture.el.querySelectorAll(".item");
+  let singleItem = fixture.el.querySelectorAll(".showroom-item");
 
   return Showroom(singleItem, {
     fetch: () => {

--- a/ftw/showroom/js/test/spec/item.js
+++ b/ftw/showroom/js/test/spec/item.js
@@ -9,7 +9,7 @@ function isUUID(uuid) {
 beforeAll(() => {
   fixture.setBase('ftw/showroom/js/test/fixtures');
   fixture.load("default_item.html");
-  defaultItem = fixture.el.querySelector(".item");
+  defaultItem = fixture.el.querySelector(".showroom-item");
 });
 
 describe("Showroom Item", () => {

--- a/ftw/showroom/js/test/spec/showroom.js
+++ b/ftw/showroom/js/test/spec/showroom.js
@@ -21,7 +21,7 @@ describe("Showroom", () => {
 
   beforeEach(() => {
     fixture.load("default_list.html");
-    defaultItems = fixture.el.querySelectorAll(".item");
+    defaultItems = fixture.el.querySelectorAll(".showroom-item");
   });
 
   afterEach(() => {
@@ -40,7 +40,7 @@ describe("Showroom", () => {
 
       assert.deepEqual(Array.from(showroom.items).map(
         item => item.element.className
-      ), ["item", "item", "item", "item", "item"]);
+      ), ["showroom-item", "showroom-item", "showroom-item", "showroom-item", "showroom-item"]);
     });
 
     it("should throw error when mixin DOM elements and with plain objects.", () => {
@@ -61,7 +61,7 @@ describe("Showroom", () => {
       fixture.load("dirty_item_list.html");
 
       assert.throws(() => {
-        Showroom(fixture.el.querySelectorAll(".item"));
+        Showroom(fixture.el.querySelectorAll(".showroom-item"));
       }, Error, "Showroom items must not contain references");
     });
 
@@ -455,7 +455,7 @@ describe("Showroom", () => {
 
       assert.deepEqual(
         showroom.items.map((item) => { return item.element.className }),
-        ["item", "item", "item", "item", "item", "item append", "item append", "item append", "item append", "item append"]
+        ["showroom-item", "showroom-item", "showroom-item", "showroom-item", "showroom-item", "showroom-item append", "showroom-item append", "showroom-item append", "showroom-item append", "showroom-item append"]
       )
     });
 
@@ -505,8 +505,8 @@ describe("Showroom", () => {
 
       assert.deepEqual(
         showroom.items.map((item) => { return item.element.className }),
-        [ "item prepend", "item prepend", "item prepend", "item prepend",
-          "item prepend", "item", "item", "item", "item", "item"]
+        [ "showroom-item prepend", "showroom-item prepend", "showroom-item prepend", "showroom-item prepend",
+          "showroom-item prepend", "showroom-item", "showroom-item", "showroom-item", "showroom-item", "showroom-item"]
       )
     });
 
@@ -633,7 +633,7 @@ describe("Showroom", () => {
       showroom.destroy();
 
       assert.deepEqual(
-        Array.from(fixture.el.querySelectorAll(".item")).map(item => item.dataset["showroom-id"]),
+        Array.from(fixture.el.querySelectorAll(".showroom-item")).map(item => item.dataset["showroom-id"]),
         [undefined, undefined, undefined, undefined, undefined]
       );
     });
@@ -829,7 +829,7 @@ describe("Showroom", () => {
       fixture.load("default_outlet.html", "default_list.html");
       let showroom = Showroom(defaultItems, {
         head: (current) => {
-          showroom.prepend(fixture.el.querySelectorAll(".item"));
+          showroom.prepend(fixture.el.querySelectorAll(".showroom-item"));
         },
         offset: 10,
         target: "#outlet",
@@ -877,7 +877,6 @@ describe("Showroom", () => {
       // Add this additional reference to the DOM after the first initialisation
       var ref = $('<a id="additional-reference" href="#" data-showroom-target-item="reference-2" class="showroom-reference"></a>');
       fixture.el.appendChild(ref[0]);
-      showroom.refresh();
 
       waitfor(() => {
         return fixture.el.querySelector(".ftw-showroom") &&

--- a/ftw/showroom/resources/showroom.js
+++ b/ftw/showroom/resources/showroom.js
@@ -353,8 +353,7 @@ module.exports = function Showroom() {
     displayCurrent: true,
     displayTotal: true,
     total: 0,
-    offset: 0,
-    references: Array.prototype.slice.call(document.querySelectorAll(".showroom-reference"))
+    offset: 0
   }, options);
 
   setOffset(options.offset);
@@ -381,13 +380,6 @@ module.exports = function Showroom() {
   items = items.map(function (item) {
     return (0, _item2.default)(item);
   });
-  items.map(function (item) {
-    return $(item.element).on("click", select);
-  });
-
-  options.references.map(function (reference) {
-    return $(reference).on("click", select);
-  });
 
   var register = (0, _register2.default)(items, { tail: options.tail, head: options.head });
   var target = $(options.target);
@@ -411,11 +403,6 @@ module.exports = function Showroom() {
     return $.get(item.target);
   };
 
-  function bindEvents() {
-    element.on("click", "#ftw-showroom-next", throttledNext);
-    element.on("click", "#ftw-showroom-prev", throttledPrev);
-  };
-
   function render(content) {
     return $.when(content).pipe(function (content) {
       return $(template({ showroom: reveal, content: content, item: register.current }));
@@ -429,7 +416,6 @@ module.exports = function Showroom() {
       element.show();
       isOpen = true;
       target.append(element).addClass("ftw-showroom-open");
-      bindEvents();
       checkArrows();
     });
   };
@@ -483,9 +469,6 @@ module.exports = function Showroom() {
     items = items.map(function (item) {
       return (0, _item2.default)(item);
     });
-    items.map(function (item) {
-      return $(item.element).on("click", select);
-    });
     register.append(items);
     checkArrows();
   }
@@ -494,9 +477,6 @@ module.exports = function Showroom() {
     items = Array.prototype.slice.call(nodes);
     items = items.map(function (item) {
       return (0, _item2.default)(item);
-    });
-    items.map(function (item) {
-      return $(item.element).on("click", select);
     });
     if (options.offset > 0) {
       options.offset -= items.length;
@@ -514,19 +494,9 @@ module.exports = function Showroom() {
     items = items.map(function (item) {
       return (0, _item2.default)(item);
     });
-    items.map(function (item) {
-      return $(item.element).on("click", select);
-    });
     setOffset(offset);
     register.reset(items);
     checkArrows();
-  }
-
-  function refresh() {
-    options.references = Array.prototype.slice.call(document.querySelectorAll(".showroom-reference"));
-    options.references.map(function (reference) {
-      return $(reference).on("click", select);
-    });
   }
 
   function destroy() {
@@ -558,13 +528,11 @@ module.exports = function Showroom() {
     return register.pointer + 1 + options.offset;
   }
 
-  target.on("click", "#ftw-showroom-close", close);
-
-  target.on("keydown", function (e) {
+  $(document).on("click", "#ftw-showroom-close", close).on("keydown", function (e) {
     event.isEscape(e, close);
     event.isArrowRight(e, throttledNext);
     event.isArrowLeft(e, throttledPrev);
-  });
+  }).on("click", ".showroom-item", select).on("click", ".showroom-reference", select).on("click", "#ftw-showroom-prev", throttledPrev).on("click", "#ftw-showroom-next", throttledNext);
 
   reveal.open = open;
   reveal.close = close;
@@ -576,7 +544,6 @@ module.exports = function Showroom() {
   reveal.destroy = destroy;
   reveal.setTotal = setTotal;
   reveal.setOffset = setOffset;
-  reveal.refresh = refresh;
 
   Object.defineProperty(reveal, "options", { get: function get() {
       return options;


### PR DESCRIPTION
Closes https://github.com/4teamwork/ftw.showroom/issues/36

Refreshing references or showroom items is not necessary when using event
delegation for event bindings.
!! Since these changes all the showroom items must have the class `showroom-item` !!
Otherwise the showroom is unable to bind the events properly.