### PR TITLE
Prevent register#set from calling head twice

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
+- Prevent register#set from calling tail twice
+  [Kevin Bieri]
+
 - Refactor event binding using event delegation.
   Since these changes all the showroom items must have `showroom-item` class
   Therefore manually refreshing events is no longer necessary

--- a/ftw/showroom/js/src/register.js
+++ b/ftw/showroom/js/src/register.js
@@ -13,7 +13,8 @@ export default function Register(items = [], options) {
 
   let reveal = {};
 
-  let oberserver = Oberserver(pointer);
+  let pointerOberserver = Oberserver(pointer);
+  let itemOberserver = Oberserver();
 
   function append(pushItems = []) {
     items = $.merge(items, pushItems);
@@ -25,8 +26,8 @@ export default function Register(items = [], options) {
   }
 
   function checkPointer() {
-    oberserver.update(pointer);
-    if(oberserver.hasChanged()) {
+    pointerOberserver.update(pointer);
+    if(pointerOberserver.hasChanged() || itemOberserver.hasChanged()) {
       performCalls();
     }
   }
@@ -41,20 +42,21 @@ export default function Register(items = [], options) {
   }
 
   function next() {
-    if(pointer < reveal.size - 1) {
+    if(hasNext()) {
       pointer += 1;
     }
     checkPointer();
   }
 
   function prev() {
-    if(pointer > 0) {
+    if(hasPrev()) {
       pointer -= 1;
     }
     checkPointer();
   }
 
   function set(item) {
+    itemOberserver.update(item);
     let index = items.indexOf(item);
     if(index === -1) {
       throw new Error("Item was not found");

--- a/ftw/showroom/js/src/showroom.js
+++ b/ftw/showroom/js/src/showroom.js
@@ -126,7 +126,6 @@ module.exports = function Showroom(items = [], options) {
     register.set(item);
     observer.update(item);
     if(observer.hasChanged()) {
-      register.performCalls();
       return showItem(item);
     }
   }

--- a/ftw/showroom/js/test/spec/register.js
+++ b/ftw/showroom/js/test/spec/register.js
@@ -259,6 +259,19 @@ describe("Register", () => {
       register.set(items[items.length - 1]);
     });
 
+    it("should call tail function just once when set to the last item", () => {
+      let items = [1, 2, 3];
+      let tailCalls = 0;
+
+      let register = Register(items, {
+        tail: () => {
+          tailCalls += 1;
+        }
+      });
+
+      register.set(items[2]);
+    });
+
   });
 
   describe("hasNext", () => {

--- a/ftw/showroom/js/test/spec/showroom.js
+++ b/ftw/showroom/js/test/spec/showroom.js
@@ -211,6 +211,21 @@ describe("Showroom", () => {
       });
       showroom.open(showroom.items[showroom.items.length - 1]);
     });
+
+    it("should execute tail call just once when opening the last item", () => {
+      let tailCalls = 0;
+
+      let showroom = Showroom(defaultItems, {
+        tail: () => {
+          tailCalls += 1;
+        },
+        total: 10,
+      });
+
+      showroom.open(showroom.items[showroom.items.length - 1]);
+
+      assert.equal(tailCalls, 1, "Tail should only be called once when opening the last item");
+    });
   });
 
   describe("close", () => {

--- a/ftw/showroom/resources/showroom.js
+++ b/ftw/showroom/resources/showroom.js
@@ -212,7 +212,8 @@ function Register() {
 
   var reveal = {};
 
-  var oberserver = (0, _observer2.default)(pointer);
+  var pointerOberserver = (0, _observer2.default)(pointer);
+  var itemOberserver = (0, _observer2.default)();
 
   function append() {
     var pushItems = arguments.length <= 0 || arguments[0] === undefined ? [] : arguments[0];
@@ -228,8 +229,8 @@ function Register() {
   }
 
   function checkPointer() {
-    oberserver.update(pointer);
-    if (oberserver.hasChanged()) {
+    pointerOberserver.update(pointer);
+    if (pointerOberserver.hasChanged() || itemOberserver.hasChanged()) {
       performCalls();
     }
   }
@@ -244,20 +245,21 @@ function Register() {
   }
 
   function next() {
-    if (pointer < reveal.size - 1) {
+    if (hasNext()) {
       pointer += 1;
     }
     checkPointer();
   }
 
   function prev() {
-    if (pointer > 0) {
+    if (hasPrev()) {
       pointer -= 1;
     }
     checkPointer();
   }
 
   function set(item) {
+    itemOberserver.update(item);
     var index = items.indexOf(item);
     if (index === -1) {
       throw new Error("Item was not found");
@@ -443,7 +445,6 @@ module.exports = function Showroom() {
     register.set(item);
     observer.update(item);
     if (observer.hasChanged()) {
-      register.performCalls();
       return showItem(item);
     }
   }


### PR DESCRIPTION
The initial pointer value is set to `0`. So when the showroom opens for the first time, the value has not been changed so the tail function is executed twice.