### PR TITLE
introduce showroom:item:shown

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -245,6 +245,28 @@ The showrooms provide the following options.
 | offset        | 0                        | Offset for the current item counter, useful for batches                  |
 +---------------+--------------------------+--------------------------------------------------------------------------+
 
+.. _events:
+
+Events
+------
+
+ftw.showroom fires the following events on `document`:
+
++---------------------+----------+-----------------------------------------------------------------------------------------------------------+
+| Event               | Params   | Description                                                                                               |
++=====================+==========+===========================================================================================================+
+| showroom:item:shown | showroom | Invoked every time an item is shown, so if showroom opens, every time the selected showroom item changes. |
++---------------------+----------+-----------------------------------------------------------------------------------------------------------+
+
+To listen to an event use the following code:
+
+.. code:: javascript
+
+  $(document).on('showroom:item:shown', function (showroom) {
+    // do something with the showroom/item
+  })
+
+
 .. _fetching:
 
 Fetching
@@ -470,4 +492,3 @@ Refreshes the showroom references.
 .. code:: javascript
 
   showroom.refresh();
-

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Introduce "showroom:item:shown" event
 
 
 1.4.0 (2017-07-11)

--- a/ftw/showroom/js/src/ftw.showroom.js
+++ b/ftw/showroom/js/src/ftw.showroom.js
@@ -107,7 +107,9 @@ module.exports = function Showroom(items = [], options) {
         element.show();
         target.append(element).addClass("ftw-showroom-open");
         checkArrows();
-    });
+      }).pipe(() => {
+	$(document).trigger("showroom:item:shown", [reveal]);
+      });
   };
 
   function beforeRender(item, content) {  }


### PR DESCRIPTION
Because we need an indicator when showroom shows an item, let's
trigger events when showroom has done something (e.g. show an item).

Also added proper documentation on how to listen to the triggered events.